### PR TITLE
update mapstruck version

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ GET /events/<correlationId>
 DELETE /events
 ```
 
+## How to produce docker image on your local
+```shell
+mvn clean package -Pdocker-image,local-client -Ddocker.repo.project=development -Djib.to.tags=local-11-05-2023-v1 -Djib.from.platforms=linux/amd64
+```
+
 ## Contributing
 
 First off, thanks for taking the time to contribute! Contributions are what makes the open-source community such an amazing place to learn, inspire, and create. Any contributions you make will benefit everybody else and are **greatly appreciated**.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.backbase.testing</groupId>
     <artifactId>event-emitter</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Backbase :: Testing Components :: Events Emitter</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <specs.repo.url>https://repo.backbase.com/specs/</specs.repo.url>
         <json-path-assert.version>2.2.0</json-path-assert.version>
         <camel-version>2.22.0</camel-version>
-        <mapstruct.version>1.3.1.Final</mapstruct.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
         <org-quartz.version>2.3.2</org-quartz.version>
         <log4j.version>2.17.1</log4j.version>
         <velocity-tools-generic.version>3.0</velocity-tools-generic.version>
@@ -137,6 +137,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
to fix `java.lang.ClassNotFoundException: org.mapstruct.ap.spi.DefaultAccessorNamingStrategy` error